### PR TITLE
Fix chime timing in popup.js

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -27,7 +27,10 @@
         gain.gain.value = volumeSlider.value;
         osc.start();
         gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + chimeDuration);
-        setTimeout(() => osc.stop(), 1000);
+        setTimeout(() => {
+            osc.stop();
+            ctx.close();
+        }, chimeDuration * 1000);
     }
 
     function updateDisplay() {


### PR DESCRIPTION
## Summary
- ensure audio context closes when chime finishes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68785d6a2e9c83239d183ddbf652940d